### PR TITLE
fix: move nested-error-stacks package to dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1600,8 +1600,7 @@
     "nested-error-stacks": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-2.1.0.tgz",
-      "integrity": "sha512-AO81vsIO1k1sM4Zrd6Hu7regmJN1NSiAja10gc4bX3F0wd+9rQmcuHQaHVQCYIEC8iFXnE+mavh23GOt7wBgug==",
-      "dev": true
+      "integrity": "sha512-AO81vsIO1k1sM4Zrd6Hu7regmJN1NSiAja10gc4bX3F0wd+9rQmcuHQaHVQCYIEC8iFXnE+mavh23GOt7wBgug=="
     },
     "netmask": {
       "version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hermione-headless-chrome",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Plugin for hermione to run integration tests on headless Chromium",
   "main": "index.js",
   "scripts": {
@@ -32,7 +32,6 @@
     "eslint": "^6.2.2",
     "eslint-config-gemini-testing": "^2.8.0",
     "mocha": "^6.2.0",
-    "nested-error-stacks": "^2.1.0",
     "proxyquire": "^2.1.3",
     "qemitter": "^2.0.0",
     "sinon": "^7.4.1"
@@ -44,6 +43,7 @@
     "gemini-configparser": "^1.0.0",
     "got": "^9.6.0",
     "lodash": "^4.17.15",
+    "nested-error-stacks": "^2.1.0",
     "ora": "^3.4.0"
   }
 }


### PR DESCRIPTION
Перенес пакет `nested-error-stacks` из `devDependencies` в `dependencies`.